### PR TITLE
create reducers folder with index.js file containing two reducers

### DIFF
--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,0 +1,24 @@
+import { combineReducers } from 'redux';
+
+const songsReducer = () => {
+    return [        
+        { artist: "Jack Johnson", title: "Go On", duration: "4:35" },
+        { artist: "Coldplay", title: "Adventure of a Lifetime", duration: "3:43" },
+        { artist: "OneRepublic", title: "Counting Stars", duration: "4:19" },
+        { artist: "U2", title: "Sometimes You Can't Make It On Your Own", duration: "4:51" }
+
+    ];
+};
+
+const selectedSongReducer = (selectedSong=null, action) => {
+    if(action.type="Song_Selected") {
+        return action.payload;
+    }
+
+    return selectedSong;
+};
+
+export default combineReducers({
+    songs: songsReducer,
+    selectedSong: selectedSongReducer
+});


### PR DESCRIPTION
A `Reducers` folder is created, with an `index.js` file inside.
There are two reducers put inside the `index.js` file.  The first reducer is the `songsReducer`, which contains an array of hard-coded songs.  Each song is an object that contains 3 pieces of information: an artist, a title, and a duration.  The second reducer is a `selectedSongReducer`, which has 2 arguments passed inside it, a `selectedSong` and an `action`.  The `selectedSong` is set  to `null` as a default.  An `if` statement is added to check if the `action.type` is `Song_Selected`, which the only action the app is starting with.  This will return the `action.payload`.  Otherwise, the function is set to return `selectedSong`.  
At the top, a named import is added for `combineReducers` from `redux`.  Then at the bottom of the code, this `combineReducers` is used.  A key of `songs` is set to the value of `songsReducer`, and a key of `selectedSong` is set to the value of `selectedSongReducer`.  This `combineReducers` is then set as the default export.