### PR TITLE
adds Provider to the main index.js file

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,16 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import App from './components/App';
 import reportWebVitals from './reportWebVitals';
+import { Provider } from 'react-redux';
+import { createStore } from 'redux';
+import App from './components/App';
+import reducers from './reducers';
 
 ReactDOM.render(
   <React.StrictMode>
-    <App />
+    <Provider store={createStore(reducers)}>
+      <App />
+    </Provider>
   </React.StrictMode>,
   document.getElementById('root')
 );


### PR DESCRIPTION
This adds the `Provider` tag to the app, inside the main `index.js` file in the `src` folder.  Also several imports are needed.
In the `App.js` file, a `Provider` component is imported from `react-redux`.  Also `createStore` is imported from `redux`.  Then `reducers` is imported from `./reducers`.  Now in the `render` of this file, the `<App>` component is wrapped with the `<Provider>`.  A prop is passed into the `<Provider>`, which will call `createStore` and pass in the `reducers`.  