### PR TITLE
adds favoriteTitle data to state and configures with SongList component

### DIFF
--- a/src/components/SongList.js
+++ b/src/components/SongList.js
@@ -9,7 +9,9 @@ class SongList extends Component {
                     <div className="right floated content">
                         <button className="ui button primary">Select</button>
                     </div>
-                    <div className="content">{song.title}</div>
+                    <div className="content">
+                        <div><b>{song.title === this.props.favoriteTitle && 'FAVORITE!'}</b></div>
+                    </div>
                 </div>
             );
         });
@@ -21,7 +23,8 @@ class SongList extends Component {
 }
 
 const mapStateToProps = state => {
-    return { songs: state.songs };
+    console.log(state);
+    return { songs: state.songs.songs, favoriteTitle: state.songs.favoriteTitle };
 }
 
 export default connect(mapStateToProps)(SongList);

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,14 +1,17 @@
 import { combineReducers } from 'redux';
 
 const songsReducer = () => {
-    return [        
+    return {
+    songs:[        
         { artist: "Jack Johnson", title: "Go On", duration: "4:35" },
         { artist: "Coldplay", title: "Adventure of a Lifetime", duration: "3:43" },
         { artist: "OneRepublic", title: "Counting Stars", duration: "4:19" },
         { artist: "U2", title: "Sometimes You Can't Make It On Your Own", duration: "4:51" }
 
-    ];
-};
+    ],
+    favoriteTitle: "Go On"
+    }
+}
 
 const selectedSongReducer = (selectedSong=null, action) => {
     if(action.type === "Song_Selected") {


### PR DESCRIPTION
The `favoriteTitle` data is added to the state in the reducers, and configured to be rendered in the `SongList` component.

In `reducers/index.js`, inside the `songsReducer` function, the `favoriteTitle` key is provided with the value of one specific song.  Also, the array of songs in this `songsReducer` function is given the key of `songs`.
In `SongList.js`, the `mapStateToProps` is updated with the additional data of `favoriteTitle` coming from the `SongsReducer`.  The `renderList` method is then configured so that it used this prop to return the data.  A child `<div>` is added inside the `<div>` containing the song titles.  A conditional is set so that if the song matches the `favoriteSong` prop, it will display "Favorite!".  