### PR TITLE
calls action creator selectSong inside SongList component

### DIFF
--- a/src/components/SongList.js
+++ b/src/components/SongList.js
@@ -1,5 +1,6 @@
 import React, {Component} from 'react';
 import { connect } from 'react-redux';
+import { selectSong } from '../actions';
 
 class SongList extends Component {
     renderList() {
@@ -7,9 +8,11 @@ class SongList extends Component {
             return (
                 <div className="item" key={song.title}>
                     <div className="right floated content">
-                        <button className="ui button primary">Select</button>
+                        <button 
+                        className="ui button primary"
+                        onClick={ () => this.props.selectSong(song) }>Select</button>
                     </div>
-                    <div className="content">
+                    <div className="content">{song.title}
                         <div><b>{song.title === this.props.favoriteTitle && 'FAVORITE!'}</b></div>
                     </div>
                 </div>
@@ -27,4 +30,4 @@ const mapStateToProps = state => {
     return { songs: state.songs.songs, favoriteTitle: state.songs.favoriteTitle };
 }
 
-export default connect(mapStateToProps)(SongList);
+export default connect(mapStateToProps, { selectSong: selectSong })(SongList);


### PR DESCRIPTION
The `selectSong` action creator is called inside `SongList.js`, and then used inside the `renderList()` method.

Inside `SongList.js`, the `selectSong` action creator is imported at the top from the `/actions` folder.  At the bottom inside of the `export`, the `selectSong` function is passed into the `connect` function as a second argument, with the key/value set to the same name of `selectSong`.  In the `renderList()` method, an `onClick` is added to the "Select" button.  The `onClick` is configured to run a function that accesses the action creator, using `this.props.selectSong`.  A single argument of `song` is passed into this function.