### PR TITLE
adds video data to songsreducer for each song

### DIFF
--- a/src/components/SongDetails.js
+++ b/src/components/SongDetails.js
@@ -9,10 +9,10 @@ const SongDetails = ({ song, favoriteTitle }) => {
     return (
         <div>
             <h3>Details for:</h3>
-            <p>Title: {song.title}</p>
             <p>Artist: {song.artist}</p>
             <p>Song duration: {song.duration}</p>
             <p><i><b>{song.title === favoriteTitle && 'FAVORITE!'}</b></i></p>
+            <iframe width="560" height="315" src={song.video} title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
         </div>
     )
 }

--- a/src/components/SongList.js
+++ b/src/components/SongList.js
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import { selectSong } from '../actions';
 
 class SongList extends Component {
-    renderList() {
+    renderList() {    
         return this.props.songs.map((song) => {
             return (
                 <div className="item" key={song.title}>

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -2,11 +2,12 @@ import { combineReducers } from 'redux';
 
 const songsReducer = () => {
     return {
-    songs:[       
-        { title: "Adventure of a Lifetime", artist: "Coldplay", duration: "3:43" }, 
-        { title: "Go On", artist: "Jack Johnson", duration: "4:35" },        
-        { title: "Counting Stars", artist: "OneRepublic", duration: "4:19" },
-        { title: "Sometimes You Can't Make It On Your Own", artist: "U2", duration: "4:51" }
+    songs:[
+        { title: "Sometimes You Can't Make It On Your Own", artist: "U2", duration: "4:51", video: "https://www.youtube.com/embed/DQZoxlBXBXA" },       
+        { title: "Adventure of a Lifetime", artist: "Coldplay", duration: "3:43", video: "https://www.youtube.com/embed/QtXby3twMmI" }, 
+        { title: "Go On", artist: "Jack Johnson", duration: "4:35", video: "https://www.youtube.com/embed/pLEx7IiE4vM" },        
+        { title: "Counting Stars", artist: "OneRepublic", duration: "4:19", video: "https://www.youtube.com/embed/hT_nvWreIhg" }
+        
     ],
     favoriteTitle: "Go On"
     }


### PR DESCRIPTION
In `SongDetails.js`, an `<iframe>` is added to the `return` of the component.  This contains the general data structure needed to render the video for each of the songs.  The `src` is set to dynamically pull in the data coming from the `songsReducer` function in `reducers/index.js`.  
In `SongList.js`, no change was made, except simple spaces in the code.
In `reducers/index.js`, changes were made in the `songsReducer` function.  For each song, a `video` key is provided, and the appropriate Youtube video src is given as the value.  This video input is added as a string.  Also, the order of the songs was slightly adjusted in the `songs` array.  